### PR TITLE
記事が何も登録されていない場合に、RSSのpublishDateを取得しようとするとエラーになる

### DIFF
--- a/date/date.go
+++ b/date/date.go
@@ -37,6 +37,14 @@ func GetLastWeekMonday(targetHour int) time.Time {
 	return nowDate.Add(time.Duration(-24*weekday) * time.Hour)
 }
 
+// Get2WeekAgoDate 2週間前以上の日付を取得する
+func Get2WeekAgoDate() time.Time {
+	nowDate := getNowDate(0)
+	weekday := 14
+	nowDate = time.Date(nowDate.Year(), nowDate.Month(), nowDate.Day(), 00, 00, 00, 0, time.Local)
+	return nowDate.Add(time.Duration(-24*weekday) * time.Hour)
+}
+
 /**
  * 現在の日付を取得する
  */

--- a/rss/rss.go
+++ b/rss/rss.go
@@ -4,6 +4,7 @@ import (
 	time "time"
 
 	database "../database"
+	date "../date"
 	gofeed "github.com/mmcdole/gofeed"
 )
 
@@ -40,6 +41,11 @@ func getLatestFeedPubDate(feedURL string, requireCount int, parser *gofeed.Parse
 	feed, err := parser.ParseURL(feedURL)
 	if err != nil {
 		panic("フィードが取得できませんでした。失敗したフィードURL => " + feedURL)
+	}
+
+	if (requireCount + 1) > len(feed.Items) {
+		// そもそも記事数が足りない場合は公開日を取得できないのでlatestは、必ず通知対象となる2週間以上前のものにセットする
+		return date.Get2WeekAgoDate()
 	}
 
 	// 最新日を取得


### PR DESCRIPTION
## :memo: 概要

タイトルの通り、ブログは登録しているけど、記事が一つもない場合、getLatestFeedPubDate内のPublishedを取得するロジック内でエラーが発生していた。

対象ブログ: https://organizer.earlybird-meeting.com


