### PR TITLE
#1 delete dynamodb data with slack slash command

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -62,6 +62,14 @@ func CreateUser(configData config.ConfigData, slackParams *slack.SlackParams) {
 	}
 }
 
+// DeleteUser ユーザーデータを削除する
+func DeleteUser(configData config.ConfigData, member WriteBlogEveryWeek) {
+	table := getTableObject(configData)
+	if err := table.Delete("user_id", member.UserID).Run(); err != nil {
+		panic("削除エラー => " + err.Error())
+	}
+}
+
 /**
  * DynamoDBのテーブルオブジェクトを取得する
  */

--- a/database/database.go
+++ b/database/database.go
@@ -63,11 +63,9 @@ func CreateUser(configData config.ConfigData, slackParams *slack.SlackParams) {
 }
 
 // DeleteUser ユーザーデータを削除する
-func DeleteUser(configData config.ConfigData, member WriteBlogEveryWeek) {
+func DeleteUser(configData config.ConfigData, member WriteBlogEveryWeek) error {
 	table := getTableObject(configData)
-	if err := table.Delete("user_id", member.UserID).Run(); err != nil {
-		panic("削除エラー => " + err.Error())
-	}
+	return table.Delete("user_id", member.UserID).Run()
 }
 
 /**

--- a/main.go
+++ b/main.go
@@ -114,7 +114,9 @@ func blogDelete(_ context.Context, rawParams interface{}) (interface{}, error) {
 	allMemberDataList := database.FindAll(configData)
 	for _, m := range allMemberDataList {
 		if m.UserName == params.Text {
-			database.DeleteUser(configData, m)
+			if err := database.DeleteUser(configData, m); err != nil {
+				return fmt.Sprintf("削除エラー => %v", err), nil
+			}
 			return fmt.Sprintf("%sさんのブログを削除しました :cry:", params.Text), nil
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -114,10 +114,12 @@ func blogDelete(_ context.Context, rawParams interface{}) (string, error) {
 	allMemberDataList := database.FindAll(configData)
 	for _, m := range allMemberDataList {
 		if m.UserName == params.Text {
+			fmt.Printf("Deleting User %v\n", m)
 			if err := database.DeleteUser(configData, m); err != nil {
-				return fmt.Sprintf("削除エラー => %v", err), nil
+				fmt.Printf("DeleteUser failed by %v\n", err)
+				return "データ削除時にエラーが発生しました", nil
 			}
-			return fmt.Sprintf("%sさんのブログを削除しました :cry:", params.Text), nil
+			return fmt.Sprintf("%sさんのブログ %s を削除しました :cry:", params.Text, m.FeedURL), nil
 		}
 	}
 	return fmt.Sprintf("該当するユーザーが登録されていません: %s", params.Text), nil

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func blogResult() {
 }
 
 // blogDelete ブログの削除ロジックを実行
-func blogDelete(_ context.Context, rawParams interface{}) (interface{}, error) {
+func blogDelete(_ context.Context, rawParams interface{}) (string, error) {
 	configData := config.GetConfigData()
 	envToken := os.Getenv("WBEW_SLACK_TOKEN")
 	params, err := slack.ParseSlackParams(rawParams)

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -64,12 +65,14 @@ func ParseSlackParams(rawParams interface{}) (result *SlackParams, err error) {
 		return
 	}
 
-	return &SlackParams{
+	slackParams := SlackParams{
 		Token:    params["token"][0],
 		UserID:   params["user_id"][0],
 		UserName: params["user_name"][0],
 		// Slash CommandでURL形式を送ると <URL>という形式になるので、先頭と末尾をtrimする
 		// また、ユーザー名が送られてきた場合は、先頭の@をtrimする
 		Text: strings.TrimRight(strings.TrimLeft(strings.TrimLeft(params["text"][0], "@"), "<"), ">"),
-	}, nil
+	}
+	fmt.Printf("SlackParams: %v", slackParams)
+	return &slackParams, nil
 }

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -69,6 +69,7 @@ func ParseSlackParams(rawParams interface{}) (result *SlackParams, err error) {
 		UserID:   params["user_id"][0],
 		UserName: params["user_name"][0],
 		// Slash CommandでURL形式を送ると <URL>という形式になるので、先頭と末尾をtrimする
-		Text: strings.TrimRight(strings.TrimLeft(params["text"][0], "<"), ">"),
+		// また、ユーザー名が送られてきた場合は、先頭の@をtrimする
+		Text: strings.TrimRight(strings.TrimLeft(strings.TrimLeft(params["text"][0], "@"), "<"), ">"),
 	}, nil
 }

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -73,6 +73,6 @@ func ParseSlackParams(rawParams interface{}) (result *SlackParams, err error) {
 		// また、ユーザー名が送られてきた場合は、先頭の@をtrimする
 		Text: strings.TrimRight(strings.TrimLeft(strings.TrimLeft(params["text"][0], "@"), "<"), ">"),
 	}
-	fmt.Printf("SlackParams: %v", slackParams)
+	fmt.Printf("SlackParams: UserID=%s, UserName=%s, Text=%s\n", slackParams.UserID, slackParams.UserName, slackParams.Text)
 	return &slackParams, nil
 }


### PR DESCRIPTION
## :ticket: Issue
#1 

## :memo: 概要
退会者が出た時に利用するDynamoDBからのデータ削除用のSlackのスラッシュコマンドを実装しました。
Slackで`/blog_delete @kdnakt `のように利用できる予定です。
テストコードがないのですが、自分のAWSアカウントで簡単に動作確認済みです。
（対象者がいない場合のメッセージ、いる場合の処理）

## :no_good_man: やってないこと
(このPRではやってないことなど書きましょう)

## :heavy_check_mark: 動作確認
(レビューアに確認してほしいことを書きましょう)
- [ ] CIのテストが全て問題ない
